### PR TITLE
Updated link to documentation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -2,4 +2,4 @@ Portlet Support
 ======
 *Portal support add on for [Vaadin Flow](https://vaadin.com/flow)*
 
-Read the documentation [here](https://github.com/vaadin/flow-and-components-documentation/blob/master/documentation/portlet-support/overview.asciidoc).
+Read the documentation [here](https://github.com/vaadin/flow-and-components-documentation/tree/master/documentation/portlet-support).


### PR DESCRIPTION
Link was broken after rename. Link to directory should be more robust.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/portlet-support/130)
<!-- Reviewable:end -->
