### PR TITLE
Set container home to downloaded pluto to avoid triggering Tomcat download

### DIFF
--- a/vaadin-portlet-integration-tests/pom.xml
+++ b/vaadin-portlet-integration-tests/pom.xml
@@ -110,7 +110,9 @@
                     <configuration>
                         <container>
                             <containerId>tomcat8x</containerId>
+	                        <home>${project.build.directory}/pluto-${pluto.version}</home>
                         </container>
+                        <type>existing</type>
                         <!-- Set an empty deployer so that cargo does not try to add the
                         current project's artifact to the container (as this was already
                         done by maven) -->


### PR DESCRIPTION
Cargo unnecessarily downloaded Tomcat, which began failing after Maven central started requiring https (https://support.sonatype.com/hc/en-us/articles/360041287334-Central-501-HTTPS-Required).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/portlet/176)
<!-- Reviewable:end -->
