### PR TITLE
fix: copy headers from StreamResource to VaadinResponse 

### DIFF
--- a/vaadin-portlet-integration-tests/tests-generic/src/main/java/com/vaadin/flow/portal/streamresource/StreamResourceContent.java
+++ b/vaadin-portlet-integration-tests/tests-generic/src/main/java/com/vaadin/flow/portal/streamresource/StreamResourceContent.java
@@ -1,0 +1,23 @@
+package com.vaadin.flow.portal.streamresource;
+
+import java.io.ByteArrayInputStream;
+
+import com.vaadin.flow.component.html.Anchor;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.server.StreamResource;
+
+public class StreamResourceContent extends VerticalLayout {
+
+    static final String FILENAME = "export.xlsx";
+
+    public StreamResourceContent() {
+        StreamResource downloadResource = new StreamResource(FILENAME,
+                () -> new ByteArrayInputStream(new byte[0]));
+        downloadResource.setContentType("application/xls");
+        downloadResource.setHeader("Content-Disposition",
+                "attachment;filename=export.xlsx");
+        Anchor link = new Anchor(downloadResource, "Download File");
+        link.setId("downloadLink");
+        add(link);
+    }
+}

--- a/vaadin-portlet-integration-tests/tests-generic/src/main/java/com/vaadin/flow/portal/streamresource/StreamResourcePortlet.java
+++ b/vaadin-portlet-integration-tests/tests-generic/src/main/java/com/vaadin/flow/portal/streamresource/StreamResourcePortlet.java
@@ -1,0 +1,7 @@
+package com.vaadin.flow.portal.streamresource;
+
+import com.vaadin.flow.portal.VaadinPortlet;
+
+public class StreamResourcePortlet
+        extends VaadinPortlet<StreamResourceContent> {
+}

--- a/vaadin-portlet-integration-tests/tests-generic/src/main/webapp/WEB-INF/portlet.xml
+++ b/vaadin-portlet-integration-tests/tests-generic/src/main/webapp/WEB-INF/portlet.xml
@@ -74,4 +74,15 @@
         </supports>
     </portlet>
 
+    <portlet>
+        <portlet-name>streamresource</portlet-name>
+        <display-name>Flow Portlet with StreamResource download</display-name>
+        <portlet-class>com.vaadin.flow.portal.streamresource.StreamResourcePortlet</portlet-class>
+        <expiration-cache>0</expiration-cache>
+        <supports>
+            <mime-type>text/html</mime-type>
+            <portlet-mode>VIEW</portlet-mode>
+        </supports>
+    </portlet>
+
 </portlet-app>

--- a/vaadin-portlet-integration-tests/tests-generic/src/test/java/com/vaadin/flow/portal/streamresource/StreamResourceIT.java
+++ b/vaadin-portlet-integration-tests/tests-generic/src/test/java/com/vaadin/flow/portal/streamresource/StreamResourceIT.java
@@ -1,0 +1,68 @@
+package com.vaadin.flow.portal.streamresource;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.JavascriptExecutor;
+
+import com.vaadin.flow.component.html.testbench.AnchorElement;
+import com.vaadin.flow.portal.AbstractPlutoPortalTest;
+
+public class StreamResourceIT extends AbstractPlutoPortalTest {
+
+    public StreamResourceIT() {
+        super("tests-generic", "streamresource");
+    }
+
+    @Test
+    public void downloadStreamResource_responseHeadersAreSent() {
+        AnchorElement link = getVaadinPortletRootElement()
+                .$(AnchorElement.class).id("downloadLink");
+        String url = link.getAttribute("href");
+        getDriver().manage().timeouts().setScriptTimeout(15, TimeUnit.SECONDS);
+
+        Map<String, String> headers = downloadAndGetResponseHeaders(url);
+
+        Assert.assertEquals(
+                "attachment;filename=" + StreamResourceContent.FILENAME,
+                headers.getOrDefault("content-disposition", null));
+    }
+
+    /*
+     * Stolen from stackexchange.
+     *
+     * It's not possible to use a straight way to download the link externally
+     * since it will use another session and the link will be invalid in this
+     * session. So either this pure client side way or external download with
+     * cookies copy (which allows preserve the session) needs to be used.
+     */
+    @SuppressWarnings("unchecked")
+    public Map<String, String> downloadAndGetResponseHeaders(String url) {
+        String script = "var url = arguments[0];"
+                + "var callback = arguments[arguments.length - 1];"
+                + "var xhr = new XMLHttpRequest();"
+                + "xhr.open('GET', url, true);"
+                + "xhr.responseType = \"arraybuffer\";" +
+                // force the HTTP response, response-type header to be array
+                // buffer
+                "xhr.onload = function() {"
+                // Get the raw header string "
+                + "  var headers = xhr.getAllResponseHeaders();"
+                // Convert the header string into an array
+                // of individual headers
+                + "  var arr = headers.trim().split(/[\\r\\n]+/);"
+                // Create a map of header names to values
+                + "  var headerMap = {};" + "  arr.forEach(function (line) { "
+                + "    var parts = line.split(': '); "
+                + "    var header = parts.shift().toLowerCase(); "
+                + "    var value = parts.join(': '); "
+                + "    headerMap[header] = value;" + "  }); "
+                + "  callback(headerMap);" + "};" + "xhr.send();";
+        Object response = ((JavascriptExecutor) getDriver())
+                .executeAsyncScript(script, url);
+        return (Map<String, String>) response;
+    }
+}

--- a/vaadin-portlet/src/main/java/com/vaadin/flow/portal/PortletStreamResourceHandler.java
+++ b/vaadin-portlet/src/main/java/com/vaadin/flow/portal/PortletStreamResourceHandler.java
@@ -25,6 +25,7 @@ public class PortletStreamResourceHandler extends StreamResourceHandler {
         try {
             setResponseContentType(request, response, streamResource);
             response.setCacheTime(streamResource.getCacheTime());
+            streamResource.getHeaders().forEach(response::setHeader);
             writer = streamResource.getWriter();
             if (writer == null) {
                 throw new IOException(
@@ -56,8 +57,7 @@ public class PortletStreamResourceHandler extends StreamResourceHandler {
     }
 
     private void setResponseContentType(VaadinRequest request,
-                                        VaadinResponse response,
-                                        StreamResource streamResource) {
+            VaadinResponse response, StreamResource streamResource) {
         PortletContext context = ((VaadinPortletRequest) request)
                 .getPortletContext();
         try {
@@ -65,8 +65,7 @@ public class PortletStreamResourceHandler extends StreamResourceHandler {
                     .apply(streamResource, null));
         } catch (NullPointerException e) {
             response.setContentType(Optional
-                    .ofNullable(
-                            context.getMimeType(streamResource.getName()))
+                    .ofNullable(context.getMimeType(streamResource.getName()))
                     .orElse("application/octet-stream"));
         }
     }

--- a/vaadin-portlet/src/main/java/com/vaadin/flow/portal/PortletStreamResourceRegistry.java
+++ b/vaadin-portlet/src/main/java/com/vaadin/flow/portal/PortletStreamResourceRegistry.java
@@ -15,12 +15,12 @@
  */
 package com.vaadin.flow.portal;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-
 import javax.portlet.MimeResponse;
 import javax.portlet.PortletResponse;
 import javax.portlet.ResourceURL;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import com.vaadin.flow.server.AbstractStreamResource;
 import com.vaadin.flow.server.StreamRegistration;
@@ -42,7 +42,8 @@ class PortletStreamResourceRegistry extends StreamResourceRegistry {
     /**
      * Creates stream resource registry for provided {@code session}.
      *
-     * @param session Vaadin portlet session
+     * @param session
+     *            Vaadin portlet session
      */
     public PortletStreamResourceRegistry(VaadinPortletSession session) {
         super(session);
@@ -54,15 +55,16 @@ class PortletStreamResourceRegistry extends StreamResourceRegistry {
     }
 
     @Override
-    public StreamRegistration registerResource(AbstractStreamResource resource) {
-        StreamRegistration streamRegistration = super.registerResource(resource);
+    public StreamRegistration registerResource(
+            AbstractStreamResource resource) {
+        StreamRegistration streamRegistration = super.registerResource(
+                resource);
         return new RegistrationWrapper(streamRegistration);
     }
 
     /**
-     * StreamRegistration implementation which embeds dynamic resource url
-     * into portlet url as a 'resourceUrl' query parameter, see
-     * {@link ResourceURL}.
+     * StreamRegistration implementation which embeds dynamic resource url into
+     * portlet url as a 'resourceUrl' query parameter, see {@link ResourceURL}.
      */
     private final class RegistrationWrapper implements StreamRegistration {
 
@@ -114,7 +116,7 @@ class PortletStreamResourceRegistry extends StreamResourceRegistry {
 
     private String startWithSlash(URI uri) {
         String uriString = uri.toString();
-        if(uriString.startsWith("/")) {
+        if (uriString.startsWith("/")) {
             return uriString;
         }
         return "/" + uriString;

--- a/vaadin-portlet/src/main/java/com/vaadin/flow/portal/PortletStreamResourceRegistry.java
+++ b/vaadin-portlet/src/main/java/com/vaadin/flow/portal/PortletStreamResourceRegistry.java
@@ -96,7 +96,13 @@ class PortletStreamResourceRegistry extends StreamResourceRegistry {
             ResourceURL resourceURL = mimeResponse.createResourceURL();
             resourceURL.setResourceID(startWithSlash(getURI(resource)));
             try {
-                return new URI("." + resourceURL);
+                // In Liferay resourceURL is absolute, whereas in Pluto it is
+                // relative
+                URI uri = new URI(resourceURL.toString());
+                if (!uri.isAbsolute()) {
+                    uri = new URI("." + uri);
+                }
+                return uri;
             } catch (URISyntaxException e) {
                 // should not happen
                 throw new RuntimeException(e);

--- a/vaadin-portlet/src/test/java/com/vaadin/flow/portal/PortletStreamResourceHandlerTest.java
+++ b/vaadin-portlet/src/test/java/com/vaadin/flow/portal/PortletStreamResourceHandlerTest.java
@@ -2,20 +2,15 @@ package com.vaadin.flow.portal;
 
 import javax.portlet.MimeResponse;
 import javax.portlet.PortletRequest;
-import javax.portlet.PortletResponse;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import com.vaadin.flow.component.UI;
-import com.vaadin.flow.server.AbstractStreamResource;
 import com.vaadin.flow.server.StreamResource;
-
-import static org.junit.Assert.*;
 
 public class PortletStreamResourceHandlerTest {
 
@@ -64,7 +59,8 @@ public class PortletStreamResourceHandlerTest {
         String headerValue = "attachment;filename=export.xlsx";
         resource.setHeader(headerName, headerValue);
         handler.handleRequest(session, request, response, resource);
-        Mockito.verify(portletResponse, Mockito.atLeastOnce()).setProperty(headerName, headerValue);
+        Mockito.verify(portletResponse, Mockito.atLeastOnce())
+                .setProperty(headerName, headerValue);
     }
 
 }

--- a/vaadin-portlet/src/test/java/com/vaadin/flow/portal/PortletStreamResourceHandlerTest.java
+++ b/vaadin-portlet/src/test/java/com/vaadin/flow/portal/PortletStreamResourceHandlerTest.java
@@ -1,0 +1,70 @@
+package com.vaadin.flow.portal;
+
+import javax.portlet.MimeResponse;
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletResponse;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.AbstractStreamResource;
+import com.vaadin.flow.server.StreamResource;
+
+import static org.junit.Assert.*;
+
+public class PortletStreamResourceHandlerTest {
+
+    private PortletStreamResourceHandler handler = new PortletStreamResourceHandler();
+    private VaadinPortletSession session;
+    private VaadinPortletService service;
+
+    @Before
+    public void init() {
+        service = Mockito.mock(VaadinPortletService.class);
+        session = new VaadinPortletSession(service) {
+            @Override
+            public boolean hasLock() {
+                return true;
+            }
+
+            @Override
+            public void lock() {
+            }
+
+            @Override
+            public void unlock() {
+            }
+
+            @Override
+            public void checkHasLock() {
+
+            }
+        };
+    }
+
+    @Test
+    public void handleRequest_shouldApplyStreamResourceHeaders()
+            throws IOException {
+        PortletRequest portletRequest = Mockito.mock(PortletRequest.class);
+        VaadinPortletRequest request = new VaadinPortletRequest(portletRequest,
+                service);
+        MimeResponse portletResponse = Mockito.mock(MimeResponse.class);
+        VaadinPortletResponse response = new VaadinPortletResponse(
+                portletResponse, service);
+
+        StreamResource resource = new StreamResource("export.xlsx",
+                () -> new ByteArrayInputStream(new byte[0]));
+        resource.setContentType("application/xls");
+        String headerName = "Content-Disposition";
+        String headerValue = "attachment;filename=export.xlsx";
+        resource.setHeader(headerName, headerValue);
+        handler.handleRequest(session, request, response, resource);
+        Mockito.verify(portletResponse, Mockito.atLeastOnce()).setProperty(headerName, headerValue);
+    }
+
+}

--- a/vaadin-portlet/src/test/java/com/vaadin/flow/portal/PortletStreamResourceRegistryTest.java
+++ b/vaadin-portlet/src/test/java/com/vaadin/flow/portal/PortletStreamResourceRegistryTest.java
@@ -85,6 +85,38 @@ public class PortletStreamResourceRegistryTest {
     }
 
     @Test
+    public void getResourceUri_mimeContent_returnsAbsoluteEmbeddedUrl() {
+        MimeResponse mimeResponse = Mockito.mock(MimeResponse.class);
+
+        final String resourceUrl = "http://localhost:8888/pluto/portal/Test/__pdtestsuite.TestPortlet1%21764587357%7C0;0/__rs2/__clcacheLevelPage/__ri0x3uidl/__ws0;normal";
+        Mockito.when(mimeResponse.createResourceURL()).thenReturn(
+                new ResourceUrlMock(resourceUrl));
+
+        VaadinPortletResponse vaadinPortletResponse =
+                new VaadinPortletResponse(mimeResponse, service);
+
+        VaadinResponse vaadinResponse = CurrentInstance.get(VaadinResponse.class);
+        UI currentUI = CurrentInstance.get(UI.class);
+        try {
+            CurrentInstance.set(VaadinResponse.class, vaadinPortletResponse);
+            CurrentInstance.set(UI.class, this.ui);
+            StreamRegistration registration = registry.registerResource(streamResourceMock);
+            URI resourceUri = registration.getResourceUri();
+            String expected = resourceUrl + "/VAADIN/dynamic/resource/42/"
+                    + resourceId + "/test.xml";
+            Assert.assertEquals(expected, resourceUri.toString());
+        } finally {
+            if (vaadinResponse != null) {
+                CurrentInstance.set(VaadinResponse.class, vaadinResponse);
+            }
+            if (currentUI != null) {
+                CurrentInstance.set(UI.class, currentUI);
+            }
+        }
+    }
+
+
+    @Test
     public void getResourceUri_nonMimeContent_returnsDirectUrl() {
         VaadinPortletResponse responseMock = Mockito.mock(VaadinPortletResponse.class);
 


### PR DESCRIPTION
## Description

Copy all headers set on a `StreamResource` to `VaadinResponse` before writing contents.
Also added support for absolute URLs in PortletStreamResourceRegistry.

Fixes #203 

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
