### PR TITLE
fix: Ensure necessary scripts are loaded into page

### DIFF
--- a/vaadin-portlet/src/main/java/com/vaadin/flow/portal/PortletBootstrapHandler.java
+++ b/vaadin-portlet/src/main/java/com/vaadin/flow/portal/PortletBootstrapHandler.java
@@ -95,23 +95,25 @@ class PortletBootstrapHandler extends SynchronizedRequestHandler {
                  LicenseChecker.checkLicense(VaadinPortletService.PROJECT_NAME,
                  VaadinPortletService.getPortletVersion());
             }
-            String initScript = String
-                    .format("<script>window.Vaadin.Flow.Portlets.registerElement('%s','%s','%s','%s','%s');</script>",
-                            tag, namespace, Collections
-                                    .list(portlet.getWindowStates("text/html"))
-                                    .stream()
-                                    .map(state -> "\"" + state.toString()
-                                            + "\"")
-                                    .collect(Collectors.joining(",", "[", "]")),
-                            Collections
-                                    .list(portlet.getPortletModes("text/html"))
-                                    .stream()
-                                    .map(mode -> "\"" + mode.toString() + "\"")
-                                    .collect(Collectors.joining(",", "[", "]")),
-                            ((RenderResponse) resp).createActionURL());
-            // For liferay send accepted window states, portlet modes and action url to add to client side data.
 
-            writer.write(initScript);
+            String registrationInstruction = String
+                    .format("window.Vaadin.Flow.Portlets.registerElement('%s','%s','%s','%s','%s');",
+                    tag, namespace,
+                    Collections.list(portlet.getWindowStates("text/html"))
+                            .stream()
+                            .map(state -> "\"" + state.toString() + "\"")
+                            .collect(Collectors.joining(",", "[", "]")),
+                    Collections.list(portlet.getPortletModes("text/html"))
+                            .stream().map(mode -> "\"" + mode.toString() + "\"")
+                            .collect(Collectors.joining(",", "[", "]")),
+                    ((RenderResponse) resp).createActionURL());
+            // For liferay send accepted window states, portlet modes and action
+            // url to add to client side data.
+
+            String initScript = portlet.portletElementRegistrationScript(request,
+                    scriptUrl, registrationInstruction);
+
+            writer.printf("<script>%s</script>", initScript);
             writer.write("<" + tag + " data-portlet-id='" + namespace
                     + "' style='width: 100%;'></" + tag + ">");
         } catch (Exception exception) {

--- a/vaadin-portlet/src/main/java/com/vaadin/flow/portal/VaadinPortlet.java
+++ b/vaadin-portlet/src/main/java/com/vaadin/flow/portal/VaadinPortlet.java
@@ -60,6 +60,7 @@ import com.vaadin.flow.server.DeploymentConfigurationFactory;
 import com.vaadin.flow.server.ServiceException;
 import com.vaadin.flow.server.SessionExpiredException;
 import com.vaadin.flow.server.VaadinConfigurationException;
+import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.shared.communication.PushMode;
@@ -659,4 +660,13 @@ public abstract class VaadinPortlet<C extends Component> extends GenericPortlet
             view.onPortletViewContextInit(context);
         }
     }
+
+    // By default, portlet registration instruction can be sent to the client
+    // as is, but some portlet containers (e.g. Liferay) may need to wrap or
+    // enhance it with more instructions.
+    String portletElementRegistrationScript(VaadinRequest request,
+            String scriptUrl, String registrationInstruction) {
+        return registrationInstruction;
+    }
+
 }

--- a/vaadin-portlet/src/main/resources/META-INF/resources/scripts/LiferayPortletRegistrationHelper.js
+++ b/vaadin-portlet/src/main/resources/META-INF/resources/scripts/LiferayPortletRegistrationHelper.js
@@ -1,0 +1,42 @@
+(function( scriptUrls, callback ) {
+
+    const alreadyLoadedScripts = [...document.querySelectorAll("script")]
+        .filter(function(el) { return scriptUrls.indexOf(el.src) >= 0; })
+        .map(function(el) { return el.src; });
+
+    const createScript = function(url) {
+        if (alreadyLoadedScripts.indexOf(url) >= 0) {
+            // Script already present on page, no need to load it again
+            return Promise.resolve(url);
+        }
+        return new Promise(function(resolve, reject) {
+            const script = document.createElement("script")
+            script.type = "text/javascript";
+            script.onload = function() {
+              resolve(url);
+            };
+            script.src = url;
+            document.getElementsByTagName( "head" )[0].appendChild( script );
+        });
+    };
+
+    const isRegistrationScriptInitialized = function() {
+        return window.Vaadin && window.Vaadin.Flow
+            && window.Vaadin.Flow.Portlets
+            && window.Vaadin.Flow.Portlets.registerElement;
+    };
+
+    const poller = function (attempt) {
+        if(isRegistrationScriptInitialized()) {
+            callback();
+        } else if (attempt < 100) {
+            // PortletMethods.js not yet loaded, try again
+            setTimeout(function() { poller(attempt + 1) }, 50);
+        } else {
+            console.log("PortletMethods.js not loaded, element cannot be registered");
+        }
+    };
+
+    Promise.all(scriptUrls.map(createScript)).then(function() { poller(0); });
+
+})


### PR DESCRIPTION
## Description

In Liferay "Content Page" edit mode, Vaadin portlets are not directly
added to the main page, but loaded into an iframe requesting the same
page in preview mode, and then added to the main page through javascript,
but they are detached from iframe before initialization is completed.
This way, scripts needed to register the portlet web component are not
added to the main document, so the webcomponent is not correctly rendered.
This patch add an additional script to BootstrapHandler response that
takes care to add needed script to main page and to postpone element
registration until they are loaded.

Fixes #202

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
