### PR TITLE
test: setup webdrivermanager and headless chrome for local development

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
         <!-- Plugins -->
         <driver.binary.downloader.maven.plugin.version>1.0.14</driver.binary.downloader.maven.plugin.version>
         <frontend.maven.plugin.version>1.5</frontend.maven.plugin.version>
-        <maven.surefire.plugin.version>2.20</maven.surefire.plugin.version>
-        <maven.failsafe.plugin.version>2.20</maven.failsafe.plugin.version>
+        <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
+        <maven.failsafe.plugin.version>2.22.2</maven.failsafe.plugin.version>
 
         <maven.war.plugin.version>3.1.0</maven.war.plugin.version>
         <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
@@ -78,6 +78,7 @@
         <flow.version>23.1-SNAPSHOT</flow.version>
         <flow.cdi.version>14.0-SNAPSHOT</flow.cdi.version>
         <jetty.version>10.0.9</jetty.version>
+        <webdrivermanager.version>5.2.3</webdrivermanager.version>
 
         <maven.test.skip>false</maven.test.skip>
     </properties>

--- a/vaadin-portlet-integration-tests/shared/pom.xml
+++ b/vaadin-portlet-integration-tests/shared/pom.xml
@@ -49,6 +49,12 @@
             <scope>compile</scope>
         </dependency>
 
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>${webdrivermanager.version}</version>
+        </dependency>
+
         <!-- Added to provide logging output as Flow uses -->
         <!-- the unbound SLF4J no-operation (NOP) logger implementation -->
         <dependency>

--- a/vaadin-portlet-liferay-integration-tests/pom.xml
+++ b/vaadin-portlet-liferay-integration-tests/pom.xml
@@ -29,7 +29,7 @@
         </tomcat.home.directory>
         <bundle.download.directory>${project.build.directory}
         </bundle.download.directory>
-        <cargo.debug.port>5005</cargo.debug.port>
+        <cargo.debug.port>5015</cargo.debug.port>
         <cargo.timeout>120000</cargo.timeout>
 
         <javax.validation.version>2.0.0.Final</javax.validation.version>

--- a/vaadin-portlet-liferay-integration-tests/vaadin-portlet-liferay-it-shared/pom.xml
+++ b/vaadin-portlet-liferay-integration-tests/vaadin-portlet-liferay-it-shared/pom.xml
@@ -72,6 +72,12 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>${webdrivermanager.version}</version>
+        </dependency>
+
     </dependencies>
 
 </project>


### PR DESCRIPTION
Improvements for testing and debugging locally:
- webrdrivermanager to automatically setup chromedriver
- headless mode to avoid opening browser windows during
  tests execution