### PR TITLE
fix: Change user password to not be pluto 

### DIFF
--- a/vaadin-portlet-integration-tests/pom.xml
+++ b/vaadin-portlet-integration-tests/pom.xml
@@ -305,6 +305,8 @@
                                               todir="${pluto.home.directory}/webapps"/>
                                         <copy file="${project.build.directory}/vaadin-portlet-static.war"
                                               todir="${pluto.home.directory}/webapps"/>
+                                        <copy file="${project.basedir}/../tomcat-users.xml"
+                                              todir="${pluto.home.directory}/conf" />
                                     </target>
                                 </configuration>
                             </execution>

--- a/vaadin-portlet-integration-tests/shared/src/main/java/com/vaadin/flow/portal/AbstractPlutoPortalTest.java
+++ b/vaadin-portlet-integration-tests/shared/src/main/java/com/vaadin/flow/portal/AbstractPlutoPortalTest.java
@@ -12,6 +12,7 @@ package com.vaadin.flow.portal;
 import javax.portlet.PortletMode;
 import javax.portlet.WindowState;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -26,6 +27,7 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import com.vaadin.flow.component.html.testbench.AnchorElement;
@@ -97,7 +99,7 @@ public abstract class AbstractPlutoPortalTest extends ParallelTest {
             final WebElement password = findElement(By.id("j_password"));
             final WebElement login = findElement(By.id("j_login"));
             username.sendKeys("pluto");
-            password.sendKeys("pluto");
+            password.sendKeys("04499401-85af");
             login.click();
         }
     }

--- a/vaadin-portlet-integration-tests/tomcat-users.xml
+++ b/vaadin-portlet-integration-tests/tomcat-users.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tomcat-users xmlns="http://tomcat.apache.org/xml"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://tomcat.apache.org/xml tomcat-users.xsd"
+              version="1.0">
+<user name="pluto" password="04499401-85af" roles="pluto,tckuser" />
+</tomcat-users>


### PR DESCRIPTION
To ignore chrome password leak detection
blocking actions, change the
default password to not be `pluto`.
Fixes #258
