### PR TITLE
fix: readAndWriteOutsideSessionLock set always false

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 
         <testbench.version>6.2.0</testbench.version>
         <vaadin.version>14.10-SNAPSHOT</vaadin.version>
-        <flow.version>2.9-SNAPSHOT</flow.version>
+        <flow.version>2.12-SNAPSHOT</flow.version>
         <flow.cdi.version>11.3-SNAPSHOT</flow.cdi.version>
         <jetty.version>9.4.9.v20180320</jetty.version>
 

--- a/vaadin-portlet/src/main/java/com/vaadin/flow/portal/PortletUidlRequestHandler.java
+++ b/vaadin-portlet/src/main/java/com/vaadin/flow/portal/PortletUidlRequestHandler.java
@@ -42,6 +42,12 @@ class PortletUidlRequestHandler extends UidlRequestHandler {
         return super.synchronizedHandleRequest(session, request, vaadinResponseWrapper);
     }
 
+    @Override
+    public boolean isReadAndWriteOutsideSessionLock() {
+        // special VaadinResponseWrapper is not compatible with returning true.
+        return false;
+    }
+
     /**
      * Wraps the portlet response to stub the writing actions so as to not
      * write the UIDL sync message, when the error occurs during RPC handling.


### PR DESCRIPTION
Special error handling of Liferay portlet is not compatible with `readAndWriteOutsideSessionLock=true` introduced in Flow 2.12.2. See https://github.com/vaadin/portlet/issues/213.
