### PR TITLE
fix: readAndWriteOutsideSessionLock set always false

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <maven.clean.plugin.version>3.0.0</maven.clean.plugin.version>
 
         <testbench.version>8.3.0</testbench.version>
-        <vaadin.version>23.3-SNAPSHOT</vaadin.version>
+        <vaadin.version>23.6-SNAPSHOT</vaadin.version>
         <flow.version>23.6-SNAPSHOT</flow.version>
         <flow.cdi.version>14.0-SNAPSHOT</flow.cdi.version>
         <jetty.version>10.0.9</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,9 +73,9 @@
         <maven.resources.plugin.version>3.0.2</maven.resources.plugin.version>
         <maven.clean.plugin.version>3.0.0</maven.clean.plugin.version>
 
-        <testbench.version>8.1.0</testbench.version>
+        <testbench.version>8.3.0</testbench.version>
         <vaadin.version>23.3-SNAPSHOT</vaadin.version>
-        <flow.version>23.3-SNAPSHOT</flow.version>
+        <flow.version>23.6-SNAPSHOT</flow.version>
         <flow.cdi.version>14.0-SNAPSHOT</flow.cdi.version>
         <jetty.version>10.0.9</jetty.version>
         <webdrivermanager.version>5.2.3</webdrivermanager.version>

--- a/vaadin-portlet-liferay-integration-tests/liferay-tests-generic/src/test/java/com/vaadin/flow/portal/liferay/streamresource/LiferayStreamResourceIT.java
+++ b/vaadin-portlet-liferay-integration-tests/liferay-tests-generic/src/test/java/com/vaadin/flow/portal/liferay/streamresource/LiferayStreamResourceIT.java
@@ -8,8 +8,8 @@
  */
 package com.vaadin.flow.portal.liferay.streamresource;
 
+import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import net.jcip.annotations.NotThreadSafe;
 import org.junit.Assert;
@@ -27,7 +27,7 @@ public class LiferayStreamResourceIT extends AbstractLiferayPortalTest {
         AnchorElement link = getVaadinPortletRootElement()
                 .$(AnchorElement.class).id("downloadLink");
         String url = link.getAttribute("href");
-        getDriver().manage().timeouts().setScriptTimeout(15, TimeUnit.SECONDS);
+        getDriver().manage().timeouts().scriptTimeout(Duration.ofSeconds(15));
 
         Map<String, String> headers = downloadAndGetResponseHeaders(url);
 

--- a/vaadin-portlet/src/main/java/com/vaadin/flow/portal/PortletUidlRequestHandler.java
+++ b/vaadin-portlet/src/main/java/com/vaadin/flow/portal/PortletUidlRequestHandler.java
@@ -41,6 +41,12 @@ class PortletUidlRequestHandler extends UidlRequestHandler {
         return super.synchronizedHandleRequest(session, request, vaadinResponseWrapper);
     }
 
+    @Override
+    public boolean isReadAndWriteOutsideSessionLock() {
+        // special VaadinResponseWrapper is not compatible with returning true.
+        return false;
+    }
+
     /**
      * Wraps the portlet response to stub the writing actions so as to not
      * write the UIDL sync message, when the error occurs during RPC handling.


### PR DESCRIPTION
Special error handling of Liferay portlet is not compatible with readAndWriteOutsideSessionLock=true introduced in Flow 23.6.3. See https://github.com/vaadin/portlet/issues/213.