### PR TITLE
test: fix dependency management for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,9 @@
         <maven.clean.plugin.version>3.0.0</maven.clean.plugin.version>
 
         <testbench.version>6.2.0</testbench.version>
-        <vaadin.version>14.10-SNAPSHOT</vaadin.version>
-        <flow.version>2.12-SNAPSHOT</flow.version>
+        <vaadin.version>14.14-SNAPSHOT</vaadin.version>
+        <flow.version>2.13-SNAPSHOT</flow.version>
+        <flow-components.version>14.14-SNAPSHOT</flow-components.version>
         <flow.cdi.version>11.3-SNAPSHOT</flow.cdi.version>
         <jetty.version>9.4.9.v20180320</jetty.version>
 

--- a/vaadin-portlet-integration-tests/cdi/pom.xml
+++ b/vaadin-portlet-integration-tests/cdi/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-button-testbench</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>${flow-components.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -86,17 +86,17 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-button-flow</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>${flow-components.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-ordered-layout-flow</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>${flow-components.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-notification-flow</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>${flow-components.version}</version>
         </dependency>
 
         <dependency>

--- a/vaadin-portlet-integration-tests/portlet30/pom.xml
+++ b/vaadin-portlet-integration-tests/portlet30/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-button-testbench</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>${flow-components.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
The pinned 2.0-SNAPSHOT version for flow components and testbench elements cannot be resolved anymore

Failed to transfer file: https://oss.sonatype.org/content/repositories/vaadin-snapshots/com/vaadin/flow-component-base/2.0-SNAPSHOT/flow-component-base-2.0-SNAPSHOT.pom.
Return code is: 503 , ReasonPhrase:Service Unavailable.

This change introduces a property to pin proper versions. It also bumps Vaadin and Flow version to the latest supported for the add-on.
